### PR TITLE
Fix content section

### DIFF
--- a/.tarignore
+++ b/.tarignore
@@ -4,8 +4,6 @@
 .drone*
 .lighthouse*
 .markdownlint*
-.jsbeautify*
-.prettier*
 example*
 gulp*
 package*

--- a/.tarignore
+++ b/.tarignore
@@ -4,6 +4,8 @@
 .drone*
 .lighthouse*
 .markdownlint*
+.jsbeautify*
+.prettier*
 example*
 gulp*
 package*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 - ENHANCEMENT
   - add new icons for different vcs providers `bitbucket`, `gitlab`
     and generic `git`
+  - add site parameter `GeekblogContentSection` to set a different name
+    for the default content section (defaults to `posts` or `post`)
 - BUGFIX
   - normalize source icon size for the icon font

--- a/exampleSite/content/posts/getting-started.md
+++ b/exampleSite/content/posts/getting-started.md
@@ -246,6 +246,9 @@ enableGitInfo = true
   # (Optional, default none) Sites main author.
   geekblogAuthor = "john-doe"
 
+  # (Optional, default posts) Set the name of the default content section.
+  geekblogContentSection = "my-pages"
+
   # (Optional, default none) Adds a "Hosted on <provider>" line to the footer.
   # Could be used if you want to give credits to your hosting provider.
   [params.geekblogHostedOn]
@@ -353,6 +356,9 @@ params:
 
   # (Optional, default none) Sites main author.
   geekblogAuthor: john-doe
+
+  # (Optional, default posts) Set the name of the default content section.
+  geekblogContentSection: "my-pages"
 
   # (Optional, default none) Adds a "Hosted on <provider>" line to the footer.
   # Could be used if you want to give credits to your hosting provider.

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -16,7 +16,7 @@
             {{ end }}
 
             <h1>{{ partial "title" . }}</h1>
-            {{ if eq .Type "posts" }}
+            {{ if or (eq .Type (default "posts" .Site.Params.GeekblogContentSection)) (eq .Type "post") }}
             <div class="gblog-post__meta">
                 <span class="no-wrap">
                     <svg class="icon date"><use xlink:href="#date"></use></svg>


### PR DESCRIPTION
Addresses #11 

By default, a default section `posts` or `post` will work and a custom one can be set by `.Params.GeekblogContentSection`