### PR TITLE
Fix sitemap URL

### DIFF
--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,3 +1,3 @@
 User-agent: *
 
-Sitemap: {{ "/sitemap.xml" | absURL }}
+Sitemap: {{ "sitemap.xml" | absURL }}


### PR DESCRIPTION
If the blog is installed in a subdirectory, `/sitemap.xml` will not include the subdirectory.