### PR TITLE
fix: prevent failing build if tags is an empty string

### DIFF
--- a/layouts/partials/head/schema.html
+++ b/layouts/partials/head/schema.html
@@ -78,7 +78,9 @@
     {{- end }}
     "url" : "{{ .Permalink }}",
     "wordCount" : "{{ .WordCount }}",
-    "genre" : [ {{ range $i, $tag := .Params.tags }}{{ if $i }}, {{ end }}"{{ $tag }}" {{ end }}]
+    {{- with $tags := .Params.tags }}
+    "genre" : [ {{ range $i, $tag := $tags }}{{ if $i }}, {{ end }}"{{ $tag }}" {{ end }}]
+    {{- end }}
 }
 </script>
 {{ end }}


### PR DESCRIPTION
Prevent failing builds if `tags` in the front matter is an empty string, e.g. `tags:` or `tags: ''`. It will still fail if tags is a non-empty string, e.g. `tags: Foo` but that's expected. 