### PR TITLE
fix: KaTeX class typo

### DIFF
--- a/layouts/shortcodes/katex.html
+++ b/layouts/shortcodes/katex.html
@@ -10,7 +10,7 @@
 {{ end }}
 <!-- prettier-ignore-end -->
 
-<span class="gdoc-katex katex{{ with .Get "class" }}{{ . }}{{ end }}">
+<span class="gblog-katex {{ with .Get "class" }}{{ . }}{{ end }}">
   {{ cond (in .Params "display") "\\[" "\\(" -}}
   {{- trim .Inner "\n" -}}
   {{- cond (in .Params "display") "\\]" "\\)" }}


### PR DESCRIPTION
I noticed that 357417f8effe19760f9a0d4646f90254afc61bbd re-introduced the `gdoc`/`gblog` typo as well as the double-increase of KaTeX's font size via `katex`.

KaTeX should use `gblog-katex` instead of `gdoc-katex`. KaTeX itself already applies the `katex` class, which caused the font size to be increased twice.