### PR TITLE
fix: fix extra space after katex shortcode

### DIFF
--- a/layouts/shortcodes/katex.html
+++ b/layouts/shortcodes/katex.html
@@ -13,5 +13,6 @@
 <span class="gblog-katex {{ with .Get "class" }}{{ . }}{{ end }}">
   {{ cond (in .Params "display") "\\[" "\\(" -}}
   {{- trim .Inner "\n" -}}
-  {{- cond (in .Params "display") "\\]" "\\)" }}
+  {{- cond (in .Params "display") "\\]" "\\)" -}}
 </span>
+{{- /* Drop trailing newlines */ -}}


### PR DESCRIPTION
Fixes: https://github.com/thegeeklab/hugo-geekblog/issues/243