### PR TITLE
feat: support mermaid codeblocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Geekblog
 
 [![Build Status](https://img.shields.io/drone/build/thegeeklab/hugo-geekblog?logo=drone&server=https%3A%2F%2Fdrone.thegeeklab.de)](https://drone.thegeeklab.de/thegeeklab/hugo-geekblog)
-[![Hugo Version](https://img.shields.io/badge/hugo-0.65-blue.svg)](https://gohugo.io)
+[![Hugo Version](https://img.shields.io/badge/hugo-0.93-blue.svg)](https://gohugo.io)
 [![GitHub release](https://img.shields.io/github/v/release/thegeeklab/hugo-geekblog)](https://github.com/thegeeklab/hugo-geekblog/releases/latest)
 [![GitHub contributors](https://img.shields.io/github/contributors/thegeeklab/hugo-geekblog)](https://github.com/thegeeklab/hugo-geekblog/graphs/contributors)
 [![License: MIT](https://img.shields.io/github/license/thegeeklab/hugo-geekblog)](https://github.com/thegeeklab/hugo-geekblog/blob/main/LICENSE)

--- a/exampleSite/content/posts/advanced/shortcodes.md
+++ b/exampleSite/content/posts/advanced/shortcodes.md
@@ -387,6 +387,37 @@ sequenceDiagram
 
 {{< /columns >}}
 
+As an alternative to shortcodes, code blocks can be used for markdown as well.
+
+{{< columns >}}
+
+<!-- prettier-ignore -->
+````tpl
+```mermaid
+flowchart LR
+A[Hard] -->|Text| B(Round)
+B --> C{Decision}
+C -->|One| D[Result 1]
+C -->|Two| E[Result 2]
+```
+````
+
+<--->
+
+<!-- spellchecker-disable -->
+<!-- prettier-ignore -->
+```mermaid
+flowchart LR
+A[Hard] -->|Text| B(Round)
+B --> C{Decision}
+C -->|One| D[Result 1]
+C -->|Two| E[Result 2]
+```
+
+<!-- spellchecker-enable -->
+
+{{< /columns >}}
+
 ## KaTeX
 
 [KaTeX](https://katex.org/) shortcode let you render math typesetting in markdown document.

--- a/exampleSite/content/posts/usage/getting-started.md
+++ b/exampleSite/content/posts/usage/getting-started.md
@@ -15,7 +15,7 @@ Geekblog is a simple Hugo theme for personal blogs. It is intentionally designed
 <!--more-->
 
 [![Build Status](https://img.shields.io/drone/build/thegeeklab/hugo-geekblog?logo=drone&server=https%3A%2F%2Fdrone.thegeeklab.de)](https://drone.thegeeklab.de/thegeeklab/hugo-geekblog)
-[![Hugo Version](https://img.shields.io/badge/hugo-0.65-blue.svg)](https://gohugo.io)
+[![Hugo Version](https://img.shields.io/badge/hugo-0.93-blue.svg)](https://gohugo.io)
 [![GitHub release](https://img.shields.io/github/v/release/thegeeklab/hugo-geekblog)](https://github.com/thegeeklab/hugo-geekblog/releases/latest)
 [![GitHub contributors](https://img.shields.io/github/contributors/thegeeklab/hugo-geekblog)](https://github.com/thegeeklab/hugo-geekblog/graphs/contributors)
 [![License: MIT](https://img.shields.io/github/license/thegeeklab/hugo-geekblog)](https://github.com/thegeeklab/hugo-geekblog/blob/main/LICENSE)

--- a/layouts/_default/_markup/render-codeblock-mermaid.html
+++ b/layouts/_default/_markup/render-codeblock-mermaid.html
@@ -1,0 +1,11 @@
+<!-- prettier-ignore-start -->
+{{ if not (.Page.Scratch.Get "mermaid") }}
+  <!-- Include mermaid only first time -->
+  <script defer src="{{ index (index .Site.Data.assets "mermaid.js") "src" | relURL }}"></script>
+  {{ .Page.Scratch.Set "mermaid" true }}
+{{ end }}
+<!-- prettier-ignore-end -->
+
+<pre class="gblog-mermaid mermaid">
+  {{- .Inner -}}
+</pre>

--- a/theme.toml
+++ b/theme.toml
@@ -5,7 +5,7 @@ description = "Hugo theme made for blogs"
 homepage = "https://hugo-geekblog.geekdocs.de/"
 demosite = "https://hugo-geekblog.geekdocs.de/"
 tags = ["blog", "responsive", "simple"]
-min_version = "0.65.0"
+min_version = "0.93.0"
 
 [author]
     name = "Robert Kaussow"


### PR DESCRIPTION
BREAKING CHANGE: Mermaid can be rendered using code blocks now as an alternative to the shortcode. To support this feature, the minimum supported Hugo version was changed to v0.93.