### PR TITLE
chore: bump hugo in ci to 0.104.3

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -26,7 +26,7 @@ steps:
       NPM_CONFIG_LOGLEVEL: error
 
   - name: testbuild
-    image: thegeeklab/hugo:0.97.3
+    image: thegeeklab/hugo:0.104.3
     commands:
       - mkdir -p exampleSite/themes/ && ln -s $(pwd)/ exampleSite/themes/hugo-geekblog
       - hugo --panicOnWarning -s exampleSite/ -b http://localhost:8000/ -e ci
@@ -206,7 +206,7 @@ steps:
         - refs/pull/**
 
   - name: build
-    image: thegeeklab/hugo:0.97.3
+    image: thegeeklab/hugo:0.104.3
     commands:
       - hugo --panicOnWarning -s exampleSite/
 
@@ -287,6 +287,6 @@ depends_on:
 
 ---
 kind: signature
-hmac: f04800844c631b0c9e17b7a7c015ca971754516f609248a380ee0db2ec2037c7
+hmac: 7124323835f4329636bb5445e8018ad366e6cbab3caec54e30edd7939603cb1a
 
 ...

--- a/exampleSite/content/posts/advanced/shortcodes.md
+++ b/exampleSite/content/posts/advanced/shortcodes.md
@@ -348,8 +348,6 @@ Boxes can be used to create a simple grid.
 
 ### Example
 
-{{< columns >}}
-
 <!-- prettier-ignore -->
 ```tpl
 {{</*/* mermaid class="text-center" */*/>}}
@@ -366,8 +364,6 @@ sequenceDiagram
 {{</*/* /mermaid */*/>}}
 ```
 
-<--->
-
 <!-- spellchecker-disable -->
 <!-- prettier-ignore -->
 {{< mermaid class="text-center" >}}
@@ -382,10 +378,6 @@ sequenceDiagram
         Bob->>Alice: Thanks for asking
     end
 {{< /mermaid >}}
-
-<!-- spellchecker-enable -->
-
-{{< /columns >}}
 
 As an alternative to shortcodes, code blocks can be used for markdown as well.
 
@@ -424,16 +416,12 @@ C -->|Two| E[Result 2]
 
 ### Example
 
-{{< columns >}}
-
 ```latex
 {{</*/* katex [display] [class="text-center"] */*/>}}
 f(x) = \int_{-\infty}^\infty\hat f(\xi)\,e^{2 \pi i \xi x}\,d\xi
 {{</*/* /katex */*/>}}
 ```
 
-<--->
-
 <!-- spellchecker-disable -->
 <!-- prettier-ignore -->
 {{< katex display >}}
@@ -442,17 +430,7 @@ f(x) = \int_{-\infty}^\infty\hat f(\xi)\,e^{2 \pi i \xi x}\,d\xi
 
 <!-- spellchecker-enable -->
 
-{{< /columns >}}
-
-KaTeX can also be used inline, for example {{< katex >}}\pi(x){{< /katex >}} or used with the `display` parameter (e.g. `display: block`):
-
-<!-- spellchecker-disable -->
-<!-- prettier-ignore -->
-{{< katex display >}}
-f(x) = \int_{-\infty}^\infty\hat f(\xi)\,e^{2 \pi i \xi x}\,d\xi
-{{< /katex >}}
-
-<!-- spellchecker-enable -->
+KaTeX can also be used inline, for example {{< katex >}}\pi(x){{< /katex >}} or used with the `display` parameter (see above).
 
 Text continues here.
 

--- a/exampleSite/content/posts/advanced/shortcodes.md
+++ b/exampleSite/content/posts/advanced/shortcodes.md
@@ -427,9 +427,9 @@ C -->|Two| E[Result 2]
 {{< columns >}}
 
 ```latex
-{{</* katex [display] [class="text-center"] */>}}
+{{</*/* katex [display] [class="text-center"] */*/>}}
 f(x) = \int_{-\infty}^\infty\hat f(\xi)\,e^{2 \pi i \xi x}\,d\xi
-{{</* /katex */>}}
+{{</*/* /katex */*/>}}
 ```
 
 <--->

--- a/exampleSite/content/posts/advanced/shortcodes.md
+++ b/exampleSite/content/posts/advanced/shortcodes.md
@@ -352,7 +352,7 @@ Boxes can be used to create a simple grid.
 
 <!-- prettier-ignore -->
 ```tpl
-{{</* mermaid class="text-center" */>}}
+{{</*/* mermaid class="text-center" */*/>}}
 sequenceDiagram
     Alice->>Bob: Hello Bob, how are you?
     alt is sick
@@ -363,7 +363,7 @@ sequenceDiagram
     opt Extra response
         Bob->>Alice: Thanks for asking
     end
-{{</* /mermaid */>}}
+{{</*/* /mermaid */*/>}}
 ```
 
 <--->

--- a/exampleSite/content/posts/advanced/shortcodes.md
+++ b/exampleSite/content/posts/advanced/shortcodes.md
@@ -430,7 +430,7 @@ f(x) = \int_{-\infty}^\infty\hat f(\xi)\,e^{2 \pi i \xi x}\,d\xi
 
 <!-- spellchecker-enable -->
 
-KaTeX can also be used inline, for example {{< katex >}}\pi(x){{< /katex >}} or used with the `display` parameter (see above).
+KaTeX can be used inline, for example {{< katex >}}\pi(x){{< /katex >}} or used with the `display` parameter (see above).
 
 Text continues here.
 

--- a/layouts/_default/_markup/render-codeblock-mermaid.html
+++ b/layouts/_default/_markup/render-codeblock-mermaid.html
@@ -6,6 +6,6 @@
 {{ end }}
 <!-- prettier-ignore-end -->
 
-<pre class="gblog-mermaid mermaid">
+<pre class="gblog-mermaid mermaid text-center">
   {{- .Inner -}}
 </pre>


### PR DESCRIPTION
Workaround related to: https://github.com/gohugoio/hugo/issues/10058

While the double escape workaround helps in general, it still fails when used together with the `toc` short code (hugo build timeout). To fix that, columns were removed for the problematic short codes.