### PR TITLE
fix: dont write color mode defaults to local storage

### DIFF
--- a/src/js/colorTheme.js
+++ b/src/js/colorTheme.js
@@ -7,7 +7,7 @@ document.addEventListener("DOMContentLoaded", (event) => {
 
   colorThemeToggle.onclick = function () {
     let lstore = Storage.namespace(THEME)
-    let currentColorTheme = lstore.get("color-theme")
+    let currentColorTheme = lstore.get("color-theme") || COLOR_THEME_AUTO
     let nextColorTheme = toggle(TOGGLE_COLOR_THEMES, currentColorTheme)
 
     lstore.set("color-theme", TOGGLE_COLOR_THEMES[nextColorTheme])
@@ -25,7 +25,6 @@ export function applyTheme(init = true) {
     : COLOR_THEME_AUTO
 
   html.setAttribute("class", "color-toggle-" + currentColorTheme)
-  lstore.set("color-theme", currentColorTheme)
 
   if (currentColorTheme === COLOR_THEME_AUTO) {
     html.removeAttribute("color-theme")

--- a/src/js/mermaid.js
+++ b/src/js/mermaid.js
@@ -3,7 +3,7 @@ const { COLOR_THEME_DARK, THEME, COLOR_THEME_AUTO } = require("./config.js")
 
 document.addEventListener("DOMContentLoaded", function (event) {
   let lstore = Storage.namespace(THEME)
-  let currentColorTheme = lstore.get("color-theme")
+  let currentColorTheme = lstore.get("color-theme") || COLOR_THEME_AUTO
   let darkModeQuery = window.matchMedia("(prefers-color-scheme: dark)")
   let darkMode = false
   let theme = "default"


### PR DESCRIPTION
Write the color mode to the browser's local storage only if the user has explicitly requested it by pressing the button.