### PR TITLE
fix: fix access to data assets in render hook

### DIFF
--- a/layouts/_default/_markup/render-codeblock-mermaid.html
+++ b/layouts/_default/_markup/render-codeblock-mermaid.html
@@ -1,7 +1,7 @@
 <!-- prettier-ignore-start -->
 {{ if not (.Page.Scratch.Get "mermaid") }}
   <!-- Include mermaid only first time -->
-  <script defer src="{{ index (index .Site.Data.assets "mermaid.js") "src" | relURL }}"></script>
+  <script defer src="{{ index (index .Page.Site.Data.assets "mermaid.js") "src" | relURL }}"></script>
   {{ .Page.Scratch.Set "mermaid" true }}
 {{ end }}
 <!-- prettier-ignore-end -->


### PR DESCRIPTION
Site variables in markdown render hooks or partials need to be accessed via global `site` function or `.Page` object.