### PR TITLE
chore: bump min hugo version to v0.128

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Geekblog
 
 [![Build Status](https://ci.thegeeklab.de/api/badges/thegeeklab/hugo-geekblog/status.svg)](https://ci.thegeeklab.de/repos/thegeeklab/hugo-geekblog)
-[![Hugo Version](https://img.shields.io/badge/hugo-0.124-blue.svg)](https://gohugo.io)
+[![Hugo Version](https://img.shields.io/badge/hugo-0.128-blue.svg)](https://gohugo.io)
 [![GitHub release](https://img.shields.io/github/v/release/thegeeklab/hugo-geekblog)](https://github.com/thegeeklab/hugo-geekblog/releases/latest)
 [![GitHub contributors](https://img.shields.io/github/contributors/thegeeklab/hugo-geekblog)](https://github.com/thegeeklab/hugo-geekblog/graphs/contributors)
 [![License: MIT](https://img.shields.io/github/license/thegeeklab/hugo-geekblog)](https://github.com/thegeeklab/hugo-geekblog/blob/main/LICENSE)

--- a/exampleSite/content/posts/usage/getting-started.md
+++ b/exampleSite/content/posts/usage/getting-started.md
@@ -15,7 +15,7 @@ Geekblog is a simple Hugo theme for personal blogs. It is intentionally designed
 <!--more-->
 
 [![Build Status](https://ci.thegeeklab.de/api/badges/thegeeklab/hugo-geekblog/status.svg)](https://ci.thegeeklab.de/repos/thegeeklab/hugo-geekblog)
-[![Hugo Version](https://img.shields.io/badge/hugo-0.124-blue.svg)](https://gohugo.io)
+[![Hugo Version](https://img.shields.io/badge/hugo-0.128-blue.svg)](https://gohugo.io)
 [![GitHub release](https://img.shields.io/github/v/release/thegeeklab/hugo-geekblog)](https://github.com/thegeeklab/hugo-geekblog/releases/latest)
 [![GitHub contributors](https://img.shields.io/github/contributors/thegeeklab/hugo-geekblog)](https://github.com/thegeeklab/hugo-geekblog/graphs/contributors)
 [![License: MIT](https://img.shields.io/github/license/thegeeklab/hugo-geekblog)](https://github.com/thegeeklab/hugo-geekblog/blob/main/LICENSE)

--- a/theme.toml
+++ b/theme.toml
@@ -5,8 +5,8 @@ description = "Hugo theme made for blogs"
 homepage = "https://hugo-geekblog.geekdocs.de/"
 demosite = "https://hugo-geekblog.geekdocs.de/"
 tags = ["blog", "responsive", "simple"]
-min_version = "0.124"
+min_version = "0.128"
 
 [author]
-    name = "Robert Kaussow"
-    homepage = "https://thegeeklab.de/"
+name = "Robert Kaussow"
+homepage = "https://thegeeklab.de/"


### PR DESCRIPTION
BREAKING CHANGE: The Hugo config key `paginate` was deprecated in Hugo v0.128.0. Please use `pagination.pagerSize` instead in your custom configuration.