### PR TITLE
chore: bump min required hugo version to 0.160

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Geekblog
 
 [![Build Status](https://ci.thegeeklab.de/api/badges/thegeeklab/hugo-geekblog/status.svg)](https://ci.thegeeklab.de/repos/thegeeklab/hugo-geekblog)
-[![Hugo Version](https://img.shields.io/badge/hugo-0.156-blue.svg)](https://gohugo.io)
+[![Hugo Version](https://img.shields.io/badge/hugo-0.160-blue.svg)](https://gohugo.io)
 [![GitHub release](https://img.shields.io/github/v/release/thegeeklab/hugo-geekblog)](https://github.com/thegeeklab/hugo-geekblog/releases/latest)
 [![GitHub contributors](https://img.shields.io/github/contributors/thegeeklab/hugo-geekblog)](https://github.com/thegeeklab/hugo-geekblog/graphs/contributors)
 [![License: MIT](https://img.shields.io/github/license/thegeeklab/hugo-geekblog)](https://github.com/thegeeklab/hugo-geekblog/blob/main/LICENSE)

--- a/exampleSite/content/posts/usage/getting-started.md
+++ b/exampleSite/content/posts/usage/getting-started.md
@@ -16,7 +16,7 @@ Geekblog is a simple Hugo theme for personal blogs. It is intentionally designed
 <!--more-->
 
 [![Build Status](https://ci.thegeeklab.de/api/badges/thegeeklab/hugo-geekblog/status.svg)](https://ci.thegeeklab.de/repos/thegeeklab/hugo-geekblog)
-[![Hugo Version](https://img.shields.io/badge/hugo-0.156-blue.svg)](https://gohugo.io)
+[![Hugo Version](https://img.shields.io/badge/hugo-0.160-blue.svg)](https://gohugo.io)
 [![GitHub release](https://img.shields.io/github/v/release/thegeeklab/hugo-geekblog)](https://github.com/thegeeklab/hugo-geekblog/releases/latest)
 [![GitHub contributors](https://img.shields.io/github/contributors/thegeeklab/hugo-geekblog)](https://github.com/thegeeklab/hugo-geekblog/graphs/contributors)
 [![License: MIT](https://img.shields.io/github/license/thegeeklab/hugo-geekblog)](https://github.com/thegeeklab/hugo-geekblog/blob/main/LICENSE)

--- a/theme.toml
+++ b/theme.toml
@@ -5,7 +5,7 @@ description = "Hugo theme made for blogs"
 homepage = "https://hugo-geekblog.geekdocs.de/"
 demosite = "https://hugo-geekblog.geekdocs.de/"
 tags = ["blog", "responsive", "simple"]
-min_version = "0.156"
+min_version = "0.160"
 
 [author]
 name = "Robert Kaussow"


### PR DESCRIPTION
Fixes: https://github.com/thegeeklab/hugo-geekblog/issues/827

BREAKING CHANGE: The minimum required version for this theme has been bumped to v0.160 due to a critical bug fix.